### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Custom View Examples#
+# Custom View Examples #
 
 This repository contains a series of sample code designed to highlight applications of creating custom Views and ViewGroups. Examples include:
 
@@ -7,7 +7,7 @@ This repository contains a series of sample code designed to highlight applicati
  - Custom View
  - Custom ViewGroup
 
-##License##
+## License ##
 
 **The code supplied here is covered under the MIT Open Source License:**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
